### PR TITLE
Cleaning up grunt usage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,7 @@
+'use strict';
+
+var loadGruntTasks = require('load-grunt-tasks');
+
 module.exports = function(grunt) {
 	var port = grunt.option('port') || 8000;
 
@@ -87,7 +91,13 @@ module.exports = function(grunt) {
 				},
 				ignores: ['src/shared/vendor/**']
 			},
-			files: [ 'Gruntfile.js', 'src/**' ]
+			files: [ 'src/**' ],
+			grunt: {
+				options: {
+					node: true
+				},
+				files: [{src: 'Gruntfile.js'}]
+			}
 		},
 		mocha_phantomjs: {
 			files: ['test/*.html']
@@ -136,17 +146,9 @@ module.exports = function(grunt) {
 		}
 	});
 
-	// Load the plugins
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-concat');
-	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('grunt-contrib-jshint');
-	grunt.loadNpmTasks('grunt-contrib-connect');
-	grunt.loadNpmTasks('grunt-notify');
-	grunt.loadNpmTasks('grunt-mocha-phantomjs');
+	loadGruntTasks(grunt);
 
 	// Default task(s).
-	// grunt.registerTask('default', ['jshint', 'concat', 'uglify', 'notify:finish']);
 	grunt.registerTask('default', ['jshint', 'concat', 'notify:finish']);
 
 	// Serve examples locally

--- a/package.json
+++ b/package.json
@@ -4,26 +4,28 @@
   "description": "3D city and data visualisation platform",
   "main": "index.js",
   "scripts": {
+    "start": "grunt && grunt serve",
     "test": "grunt test --verbose"
   },
   "author": "Robin Hawkes & Peter Smart",
   "license": "MIT",
   "devDependencies": {
+    "chai": "~1.9.0",
     "grunt": "~0.4.1",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-uglify": "~0.2.2",
-    "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-connect": "~0.5.0",
-    "grunt-notify": "~0.2.15",
-    "mocha": "~1.17.1",
     "grunt-mocha-phantomjs": "~0.4.0",
-    "chai": "~1.9.0",
+    "grunt-notify": "~0.2.15",
+    "load-grunt-tasks": "^3.2.0",
+    "mocha": "~1.17.1",
     "sinon": "~1.8.1",
     "sinon-chai": "~2.5.0"
   },
-  "repository" :
-  { "type" : "git"
-  , "url" : "https://github.com/robhawkes/vizicities.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robhawkes/vizicities.git"
   }
 }


### PR DESCRIPTION
The deps in `package.json` are reordered by `npm` because I did `npm install --save-dev`. 

These are just some best practices and general cleanup changes. Let me know if you want explanation on any of them.